### PR TITLE
Version 6.1.1

### DIFF
--- a/lib/zlocalize/source_processor.rb
+++ b/lib/zlocalize/source_processor.rb
@@ -1,4 +1,11 @@
 require 'parser/all'
+# NOTE: This prevents Rails test environment to complain about this:
+#       `ActionView::Template::Error: undefined method 'new' for module Erubi`
+#       somehow Bundler or the autoload mechanism gets confused about which Erubi
+#       implementation is defined
+unless defined?(ActionView::Template::Handlers::ERB::Erubi)
+  require 'action_view/template/handlers/erb/erubi'
+end
 require 'action_view/template/handlers/erb/erubi'
 require File.join(File.dirname(__FILE__),'translation_file')
 require File.join(File.dirname(__FILE__),'harvester')

--- a/lib/zlocalize/translation_file.rb
+++ b/lib/zlocalize/translation_file.rb
@@ -243,7 +243,7 @@ module ZLocalize
     end
 
     def non_translated_entries
-      @entries.sort_by_id.collect { |e| e.translation.to_s.strip == "" }
+      @entries.sort_by_id.select { |e| e.translation.to_s.strip == "" }
     end
 
    end # class TranlationFile

--- a/zlocalize.gemspec
+++ b/zlocalize.gemspec
@@ -37,7 +37,11 @@ Gem::Specification.new do |s|
     s.add_dependency('activesupport', ">= #{rails_version}")
     s.add_dependency('actionpack',    ">= #{rails_version}")
     s.add_dependency('i18n',          [">= 0.7", "< 2"])
-    s.add_dependency('parser',        ">= 2.7")
+    if RUBY_VERSION < "3.4.0"
+      s.add_dependency('parser',        ">= 2.7")
+    else
+      s.add_dependency('prism', ">= 1.2")
+    end
   end
 
 end

--- a/zlocalize.gemspec
+++ b/zlocalize.gemspec
@@ -2,7 +2,7 @@ rails_version = '5.2'
 
 Gem::Specification.new do |s|
   s.name        = 'zlocalize'
-  s.version     = '6.0.8'
+  s.version     = '6.1.1'
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]


### PR DESCRIPTION
Hotfix for Rails 8.1.2 test environment. Basically work around the autoload mechanism which gets confused about which `Erubi` implementation is defined.